### PR TITLE
Rebuild planar and spatial control notebooks

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,43 @@
+# Cuadernos de control cinemático
+
+Los cuadernos de este directorio documentan paso a paso la obtención de la cinemática directa, la matriz Jacobiana y un control cinemático por lazo cerrado para manipuladores planares y espaciales sencillos.
+
+## Estructura
+
+- `control/control_pr.ipynb`: Robot con primera junta prismática y segunda rotacional.
+- `control/control_rp.ipynb`: Robot con primera junta rotacional y segunda prismática.
+- `control/control_rr.ipynb`: Robot con dos juntas rotacionales en el plano.
+- `control/control_rrr.ipynb`: Robot planar de tres juntas rotacionales con seguimiento de pose (x, y, θ).
+- `control/control_4dof.ipynb`: Manipulador espacial de cuatro grados de libertad con control de (x, y, z, pitch).
+- `control/utils.py`: Rutinas compartidas para generar trayectorias de referencia, vectores de tiempo y gráficas de seguimiento.
+
+Cada cuaderno sigue la misma estructura: configuración, modelo cinemático, control, simulación, validación de errores máximos y animación de la trayectoria circular asociada.
+
+> **Nota:** Los cuadernos originales usados como punto de partida (`Control Cinemático PR.ipynb`, `Control Cinemático RP.ipynb` y `Frames Tests.ipynb`) se conservaron en la raíz del repositorio para referencia histórica.
+
+## Uso del módulo `utils` en Google Colab
+
+Para ejecutar los cuadernos en Colab manteniendo las utilidades compartidas:
+
+1. Clona este repositorio (o descarga el ZIP) dentro de tu sesión de Colab. Un ejemplo mínimo usando `git` es:
+   ```python
+   !git clone https://github.com/<TU_USUARIO>/Robotics.git
+   %cd Robotics
+   ```
+   Si solo subes los cuadernos de manera individual, asegúrate de subir también el archivo `notebooks/control/utils.py` o arrastra la carpeta completa `notebooks/control/` al panel de archivos de Colab.
+2. Añade la carpeta del proyecto (o específicamente `notebooks/control/`) al `sys.path` de Python para que Colab encuentre el módulo:
+   ```python
+   import sys
+   from pathlib import Path
+
+   control_path = Path.cwd() / 'notebooks' / 'control'
+   if str(control_path) not in sys.path:
+       sys.path.append(str(control_path))
+   ```
+3. Importa las utilidades en el cuaderno de Colab:
+   ```python
+   from utils import time_vector, circular_task_reference, plot_tracking
+   ```
+4. Ejecuta el cuaderno normalmente. Los bloques de verificación (`assert`) incluidos en cada notebook confirman que la simulación produce errores máximos aceptables antes de graficar.
+
+Con estos pasos Colab localizará `utils.py` sin necesidad de modificar rutas dentro de los cuadernos.

--- a/notebooks/control/control_4dof.ipynb
+++ b/notebooks/control/control_4dof.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Control Cinemático 4 GDL espacial\n",
+    "\n",
+    "Seguimiento de una trayectoria circular en el plano XZ para un manipulador con cuatro articulaciones rotacionales (4 eslabones) controlando posición $(x, y, z)$ y orientación de pitch."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuración de simulación"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import pathlib\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import animation\n",
+    "from IPython.display import HTML\n",
+    "\n",
+    "plt.rcParams['animation.embed_limit'] = 80\n",
+    "\n",
+    "ROOT = pathlib.Path().resolve().parents[1]\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.append(str(ROOT))\n",
+    "\n",
+    "from notebooks.control.utils import time_vector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sim_config = {\"t0\": 0.0, \"tf\": 24.0, \"n_steps\": 720}\n",
+    "radius = 0.12\n",
+    "center_x = 0.25\n",
+    "center_z = 0.25\n",
+    "constant_y = 0.04\n",
+    "omega = 2 * np.pi / (sim_config[\"tf\"] - sim_config[\"t0\"])\n",
+    "\n",
+    "t, dt = time_vector(sim_config)\n",
+    "\n",
+    "x_ref = center_x + radius * np.cos(omega * t)\n",
+    "y_ref = np.full_like(t, constant_y)\n",
+    "z_ref = center_z + radius * np.sin(omega * t)\n",
+    "\n",
+    "xd_dot = np.gradient(x_ref, dt)\n",
+    "yd_dot = np.gradient(y_ref, dt)\n",
+    "zd_dot = np.gradient(z_ref, dt)\n",
+    "\n",
+    "pitch_ref = np.unwrap(np.arctan2(zd_dot, xd_dot))\n",
+    "pitch_dot = np.gradient(pitch_ref, dt)\n",
+    "\n",
+    "Xd = np.vstack((x_ref, y_ref, z_ref, pitch_ref))\n",
+    "Vd = np.vstack((xd_dot, yd_dot, zd_dot, pitch_dot))\n",
+    "\n",
+    "L1 = 0.12\n",
+    "L2 = 0.18\n",
+    "L3 = 0.16\n",
+    "L4 = 0.12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Modelo cinemático\n",
+    "Se definen las funciones de cinemática directa y Jacobiano analítico para el vector de estado $[x, y, z, \theta]$ (pitch)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def forward_kinematics(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2, q3, q4 = q\n",
+    "    c1, s1 = np.cos(q1), np.sin(q1)\n",
+    "    s2, c2 = np.sin(q2), np.cos(q2)\n",
+    "    s23, c23 = np.sin(q2 + q3), np.cos(q2 + q3)\n",
+    "    s234, c234 = np.sin(q2 + q3 + q4), np.cos(q2 + q3 + q4)\n",
+    "\n",
+    "    radial = L2 * c2 + L3 * c23 + L4 * c234\n",
+    "    x = c1 * radial\n",
+    "    y = s1 * radial\n",
+    "    z = L1 + L2 * s2 + L3 * s23 + L4 * s234\n",
+    "    pitch = q2 + q3 + q4\n",
+    "    return np.array([x, y, z, pitch])\n",
+    "\n",
+    "\n",
+    "def jacobian(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2, q3, q4 = q\n",
+    "    c1, s1 = np.cos(q1), np.sin(q1)\n",
+    "    s2, c2 = np.sin(q2), np.cos(q2)\n",
+    "    s23, c23 = np.sin(q2 + q3), np.cos(q2 + q3)\n",
+    "    s234, c234 = np.sin(q2 + q3 + q4), np.cos(q2 + q3 + q4)\n",
+    "\n",
+    "    radial = L2 * c2 + L3 * c23 + L4 * c234\n",
+    "    dr_dq2 = -L2 * s2 - L3 * s23 - L4 * s234\n",
+    "    dr_dq3 = -L3 * s23 - L4 * s234\n",
+    "    dr_dq4 = -L4 * s234\n",
+    "\n",
+    "    dz_dq2 = L2 * c2 + L3 * c23 + L4 * c234\n",
+    "    dz_dq3 = L3 * c23 + L4 * c234\n",
+    "    dz_dq4 = L4 * c234\n",
+    "\n",
+    "    J = np.array(\n",
+    "        [\n",
+    "            [-s1 * radial, c1 * dr_dq2, c1 * dr_dq3, c1 * dr_dq4],\n",
+    "            [c1 * radial, s1 * dr_dq2, s1 * dr_dq3, s1 * dr_dq4],\n",
+    "            [0.0, dz_dq2, dz_dq3, dz_dq4],\n",
+    "            [0.0, 1.0, 1.0, 1.0],\n",
+    "        ]\n",
+    "    )\n",
+    "    return J"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Control cinemático"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "Kp = np.diag([8.0, 8.0, 8.0, 4.0])\n",
+    "q = np.zeros((4, t.size))\n",
+    "q[:, 0] = np.array([0.0, np.pi / 6, -np.pi / 6, 0.0])\n",
+    "X = np.zeros((4, t.size))\n",
+    "\n",
+    "for k in range(t.size - 1):\n",
+    "    X[:, k] = forward_kinematics(q[:, k])\n",
+    "    error = Xd[:, k] - X[:, k]\n",
+    "    error[3] = (error[3] + np.pi) % (2 * np.pi) - np.pi\n",
+    "    v_ref = Vd[:, k] + Kp @ error\n",
+    "    J = jacobian(q[:, k])\n",
+    "    dq = np.linalg.pinv(J) @ v_ref\n",
+    "    q[:, k + 1] = q[:, k] + dq * dt\n",
+    "\n",
+    "X[:, -1] = forward_kinematics(q[:, -1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Validación del error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "pos_error = np.linalg.norm(Xd[:3] - X[:3], axis=0)\n",
+    "pitch_error = ((Xd[3] - X[3]) + np.pi) % (2 * np.pi) - np.pi\n",
+    "max_pos_error = float(pos_error.max())\n",
+    "max_pitch_error = float(np.abs(pitch_error).max())\n",
+    "print(f\"Error máximo de posición: {max_pos_error:.4f} m\")\n",
+    "print(f\"Error máximo de pitch: {np.degrees(max_pitch_error):.2f} grados\")\n",
+    "assert max_pos_error < 0.03, \"El error de posición excede 3 cm\"\n",
+    "assert max_pitch_error < np.deg2rad(3.0), \"El error de pitch excede 3 grados\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Gráficas de seguimiento"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(2, 2, figsize=(12, 8))\n",
+    "labels = [\"x\", \"y\", \"z\", \"pitch\"]\n",
+    "for i, ax in enumerate(axes.flat):\n",
+    "    ax.plot(t, Xd[i], \"--\", label=\"Deseada\")\n",
+    "    ax.plot(t, X[i], label=\"Seguimiento\")\n",
+    "    ax.set_xlabel(\"Tiempo [s]\")\n",
+    "    ax.set_ylabel(labels[i])\n",
+    "    ax.legend()\n",
+    "    ax.grid(True)\n",
+    "fig.tight_layout()\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Animación 3D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def arm_points(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2, q3, q4 = q\n",
+    "    c1, s1 = np.cos(q1), np.sin(q1)\n",
+    "    s2, c2 = np.sin(q2), np.cos(q2)\n",
+    "    s23, c23 = np.sin(q2 + q3), np.cos(q2 + q3)\n",
+    "    s234, c234 = np.sin(q2 + q3 + q4), np.cos(q2 + q3 + q4)\n",
+    "\n",
+    "    base = np.array([0.0, 0.0, 0.0])\n",
+    "    joint1 = np.array([0.0, 0.0, L1])\n",
+    "\n",
+    "    r2 = L2 * c2\n",
+    "    z2 = L1 + L2 * s2\n",
+    "    joint2 = np.array([c1 * r2, s1 * r2, z2])\n",
+    "\n",
+    "    r3 = L2 * c2 + L3 * c23\n",
+    "    z3 = L1 + L2 * s2 + L3 * s23\n",
+    "    joint3 = np.array([c1 * r3, s1 * r3, z3])\n",
+    "\n",
+    "    r4 = L2 * c2 + L3 * c23 + L4 * c234\n",
+    "    z4 = L1 + L2 * s2 + L3 * s23 + L4 * s234\n",
+    "    ee = np.array([c1 * r4, s1 * r4, z4])\n",
+    "\n",
+    "    return np.stack((base, joint1, joint2, joint3, ee), axis=1)\n",
+    "\n",
+    "\n",
+    "fig = plt.figure(figsize=(6, 6))\n",
+    "ax = fig.add_subplot(111, projection=\"3d\")\n",
+    "ax.set_xlim(0.0, 0.6)\n",
+    "ax.set_ylim(-0.4, 0.4)\n",
+    "ax.set_zlim(0.0, 0.6)\n",
+    "ax.set_xlabel(\"x [m]\")\n",
+    "ax.set_ylabel(\"y [m]\")\n",
+    "ax.set_zlabel(\"z [m]\")\n",
+    "ax.set_title(\"Trayectoria circular en plano XZ\")\n",
+    "ax.plot(x_ref, y_ref, z_ref, \"--\", color=\"tab:orange\", label=\"Trayectoria deseada\")\n",
+    "arm_line, = ax.plot([], [], [], \"o-\", color=\"tab:blue\", lw=2, label=\"Robot\")\n",
+    "ax.legend(loc=\"upper left\")\n",
+    "\n",
+    "frames = range(0, t.size, 3)\n",
+    "\n",
+    "\n",
+    "def init():\n",
+    "    arm_line.set_data([], [])\n",
+    "    arm_line.set_3d_properties([])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "def animate(i):\n",
+    "    pts = arm_points(q[:, i])\n",
+    "    arm_line.set_data(pts[0], pts[1])\n",
+    "    arm_line.set_3d_properties(pts[2])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "anim = animation.FuncAnimation(\n",
+    "    fig, animate, init_func=init, frames=frames, interval=40, blit=True\n",
+    ")\n",
+    "HTML(anim.to_jshtml())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/control/control_pr.ipynb
+++ b/notebooks/control/control_pr.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Control Cinemático PR\n",
+    "\n",
+    "Seguimiento de trayectorias circulares para un manipulador con una articulación prismática seguida de una articulación rotacional."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuración del experimento\n",
+    "Definimos la duración de la simulación, el radio de la trayectoria y los parámetros geométricos del robot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import pathlib\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import animation\n",
+    "from IPython.display import HTML\n",
+    "\n",
+    "plt.rcParams['animation.embed_limit'] = 60\n",
+    "\n",
+    "ROOT = pathlib.Path().resolve().parents[1]\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.append(str(ROOT))\n",
+    "\n",
+    "from notebooks.control.utils import time_vector, circular_task_reference, plot_tracking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sim_config = {\"t0\": 0.0, \"tf\": 20.0, \"n_steps\": 600}\n",
+    "radius = 0.12\n",
+    "center = (0.25, 0.18)\n",
+    "omega = 2 * np.pi / (sim_config[\"tf\"] - sim_config[\"t0\"])\n",
+    "\n",
+    "t, dt = time_vector(sim_config)\n",
+    "Xd, Vd = circular_task_reference(radius, center, omega, t)\n",
+    "\n",
+    "L2 = 0.25"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Modelo cinemático\n",
+    "Funciones para el cálculo de la cinemática directa y la matriz Jacobiana del manipulador PR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def forward_kinematics(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    x = q1 + L2 * np.cos(q2)\n",
+    "    y = L2 * np.sin(q2)\n",
+    "    return np.array([x, y])\n",
+    "\n",
+    "\n",
+    "def jacobian(q: np.ndarray) -> np.ndarray:\n",
+    "    _, q2 = q\n",
+    "    return np.array(\n",
+    "        [\n",
+    "            [1.0, -L2 * np.sin(q2)],\n",
+    "            [0.0, L2 * np.cos(q2)],\n",
+    "        ]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Control cinemático\n",
+    "Aplicamos un controlador proporcional en el espacio cartesiano y resolvemos las velocidades articulares con la pseudo-inversa del Jacobiano."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "Kp = np.diag([6.0, 6.0])\n",
+    "q = np.zeros((2, t.size))\n",
+    "q[:, 0] = np.array([center[0], np.pi / 6])\n",
+    "X = np.zeros((2, t.size))\n",
+    "\n",
+    "for k in range(t.size - 1):\n",
+    "    X[:, k] = forward_kinematics(q[:, k])\n",
+    "    error = Xd[:, k] - X[:, k]\n",
+    "    v_ref = Vd[:, k] + Kp @ error\n",
+    "    J = jacobian(q[:, k])\n",
+    "    dq = np.linalg.pinv(J) @ v_ref\n",
+    "    q[:, k + 1] = q[:, k] + dq * dt\n",
+    "\n",
+    "X[:, -1] = forward_kinematics(q[:, -1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Verificación del error\n",
+    "Comprobamos que el error máximo de seguimiento se mantiene dentro de un umbral tolerable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "tracking_error = np.linalg.norm(Xd - X, axis=0)\n",
+    "max_error = float(tracking_error.max())\n",
+    "print(f\"Error máximo de seguimiento: {max_error:.4f} m\")\n",
+    "assert max_error < 0.02, \"El error de seguimiento excede el umbral de 2 cm\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Trayectoria y errores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig = plot_tracking(X, Xd, t)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Animación del movimiento\n",
+    "Se visualiza el desplazamiento del efector final sobre la trayectoria circular."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def arm_points(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    base = np.array([0.0, 0.0])\n",
+    "    joint = np.array([q1, 0.0])\n",
+    "    end = joint + L2 * np.array([np.cos(q2), np.sin(q2)])\n",
+    "    return np.stack((base, joint, end), axis=1)\n",
+    "\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 5))\n",
+    "ax.set_aspect(\"equal\", adjustable=\"box\")\n",
+    "ax.set_xlim(0.0, 0.6)\n",
+    "ax.set_ylim(-0.2, 0.6)\n",
+    "ax.set_xlabel(\"x [m]\")\n",
+    "ax.set_ylabel(\"y [m]\")\n",
+    "ax.set_title(\"Control cinemático PR\")\n",
+    "ax.plot(Xd[0], Xd[1], \"--\", color=\"tab:orange\", label=\"Trayectoria deseada\")\n",
+    "arm_line, = ax.plot([], [], \"o-\", lw=2, color=\"tab:blue\", label=\"Robot\")\n",
+    "ax.legend(loc=\"upper right\")\n",
+    "\n",
+    "frames = range(0, t.size, 2)\n",
+    "\n",
+    "\n",
+    "def init():\n",
+    "    arm_line.set_data([], [])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "def animate(i):\n",
+    "    pts = arm_points(q[:, i])\n",
+    "    arm_line.set_data(pts[0], pts[1])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "anim = animation.FuncAnimation(\n",
+    "    fig, animate, init_func=init, frames=frames, interval=50, blit=True\n",
+    ")\n",
+    "HTML(anim.to_jshtml())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/control/control_rp.ipynb
+++ b/notebooks/control/control_rp.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Control Cinemático RP\n",
+    "\n",
+    "Seguimiento circular para un manipulador con una articulación rotacional y otra prismática."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuración"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import pathlib\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import animation\n",
+    "from IPython.display import HTML\n",
+    "\n",
+    "plt.rcParams['animation.embed_limit'] = 60\n",
+    "\n",
+    "ROOT = pathlib.Path().resolve().parents[1]\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.append(str(ROOT))\n",
+    "\n",
+    "from notebooks.control.utils import time_vector, circular_task_reference, plot_tracking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sim_config = {\"t0\": 0.0, \"tf\": 20.0, \"n_steps\": 600}\n",
+    "radius = 0.12\n",
+    "center = (0.28, 0.12)\n",
+    "omega = 2 * np.pi / (sim_config[\"tf\"] - sim_config[\"t0\"])\n",
+    "\n",
+    "t, dt = time_vector(sim_config)\n",
+    "Xd, Vd = circular_task_reference(radius, center, omega, t)\n",
+    "\n",
+    "L1 = 0.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Modelo cinemático"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def forward_kinematics(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    reach = L1 + q2\n",
+    "    x = reach * np.cos(q1)\n",
+    "    y = reach * np.sin(q1)\n",
+    "    return np.array([x, y])\n",
+    "\n",
+    "\n",
+    "def jacobian(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    reach = L1 + q2\n",
+    "    return np.array(\n",
+    "        [\n",
+    "            [-reach * np.sin(q1), np.cos(q1)],\n",
+    "            [reach * np.cos(q1), np.sin(q1)],\n",
+    "        ]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Control cinemático"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "Kp = np.diag([6.0, 6.0])\n",
+    "q = np.zeros((2, t.size))\n",
+    "q[:, 0] = np.array([np.pi / 4, 0.05])\n",
+    "X = np.zeros((2, t.size))\n",
+    "\n",
+    "for k in range(t.size - 1):\n",
+    "    X[:, k] = forward_kinematics(q[:, k])\n",
+    "    error = Xd[:, k] - X[:, k]\n",
+    "    v_ref = Vd[:, k] + Kp @ error\n",
+    "    J = jacobian(q[:, k])\n",
+    "    dq = np.linalg.pinv(J) @ v_ref\n",
+    "    q[:, k + 1] = q[:, k] + dq * dt\n",
+    "\n",
+    "X[:, -1] = forward_kinematics(q[:, -1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Verificación del error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "tracking_error = np.linalg.norm(Xd - X, axis=0)\n",
+    "max_error = float(tracking_error.max())\n",
+    "print(f\"Error máximo de seguimiento: {max_error:.4f} m\")\n",
+    "assert max_error < 0.02, \"El error de seguimiento excede el umbral de 2 cm\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Trayectorias"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig = plot_tracking(X, Xd, t)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Animación"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def arm_points(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    base = np.array([0.0, 0.0])\n",
+    "    joint = L1 * np.array([np.cos(q1), np.sin(q1)])\n",
+    "    end = joint + q2 * np.array([np.cos(q1), np.sin(q1)])\n",
+    "    return np.stack((base, joint, end), axis=1)\n",
+    "\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 5))\n",
+    "ax.set_aspect(\"equal\", adjustable=\"box\")\n",
+    "ax.set_xlim(-0.2, 0.6)\n",
+    "ax.set_ylim(-0.2, 0.6)\n",
+    "ax.set_xlabel(\"x [m]\")\n",
+    "ax.set_ylabel(\"y [m]\")\n",
+    "ax.set_title(\"Control cinemático RP\")\n",
+    "ax.plot(Xd[0], Xd[1], \"--\", color=\"tab:orange\", label=\"Trayectoria deseada\")\n",
+    "arm_line, = ax.plot([], [], \"o-\", lw=2, color=\"tab:blue\", label=\"Robot\")\n",
+    "ax.legend(loc=\"upper right\")\n",
+    "\n",
+    "frames = range(0, t.size, 2)\n",
+    "\n",
+    "\n",
+    "def init():\n",
+    "    arm_line.set_data([], [])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "def animate(i):\n",
+    "    pts = arm_points(q[:, i])\n",
+    "    arm_line.set_data(pts[0], pts[1])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "anim = animation.FuncAnimation(\n",
+    "    fig, animate, init_func=init, frames=frames, interval=50, blit=True\n",
+    ")\n",
+    "HTML(anim.to_jshtml())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/control/control_rr.ipynb
+++ b/notebooks/control/control_rr.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Control Cinemático RR\n",
+    "\n",
+    "Manipulador planar de dos articulaciones rotacionales siguiendo una trayectoria circular."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuración"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import pathlib\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import animation\n",
+    "from IPython.display import HTML\n",
+    "\n",
+    "plt.rcParams['animation.embed_limit'] = 60\n",
+    "\n",
+    "ROOT = pathlib.Path().resolve().parents[1]\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.append(str(ROOT))\n",
+    "\n",
+    "from notebooks.control.utils import time_vector, circular_task_reference, plot_tracking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sim_config = {\"t0\": 0.0, \"tf\": 20.0, \"n_steps\": 600}\n",
+    "radius = 0.1\n",
+    "center = (0.25, 0.15)\n",
+    "omega = 2 * np.pi / (sim_config[\"tf\"] - sim_config[\"t0\"])\n",
+    "\n",
+    "t, dt = time_vector(sim_config)\n",
+    "Xd, Vd = circular_task_reference(radius, center, omega, t)\n",
+    "\n",
+    "L1 = 0.18\n",
+    "L2 = 0.18"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Modelo cinemático"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def forward_kinematics(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    x = L1 * np.cos(q1) + L2 * np.cos(q1 + q2)\n",
+    "    y = L1 * np.sin(q1) + L2 * np.sin(q1 + q2)\n",
+    "    return np.array([x, y])\n",
+    "\n",
+    "\n",
+    "def jacobian(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    s1 = np.sin(q1)\n",
+    "    c1 = np.cos(q1)\n",
+    "    s12 = np.sin(q1 + q2)\n",
+    "    c12 = np.cos(q1 + q2)\n",
+    "    return np.array(\n",
+    "        [\n",
+    "            [-L1 * s1 - L2 * s12, -L2 * s12],\n",
+    "            [L1 * c1 + L2 * c12, L2 * c12],\n",
+    "        ]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Control cinemático"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "Kp = np.diag([6.0, 6.0])\n",
+    "q = np.zeros((2, t.size))\n",
+    "q[:, 0] = np.array([np.pi / 4, -np.pi / 6])\n",
+    "X = np.zeros((2, t.size))\n",
+    "\n",
+    "for k in range(t.size - 1):\n",
+    "    X[:, k] = forward_kinematics(q[:, k])\n",
+    "    error = Xd[:, k] - X[:, k]\n",
+    "    v_ref = Vd[:, k] + Kp @ error\n",
+    "    J = jacobian(q[:, k])\n",
+    "    dq = np.linalg.pinv(J) @ v_ref\n",
+    "    q[:, k + 1] = q[:, k] + dq * dt\n",
+    "\n",
+    "X[:, -1] = forward_kinematics(q[:, -1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Verificación del error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "tracking_error = np.linalg.norm(Xd - X, axis=0)\n",
+    "max_error = float(tracking_error.max())\n",
+    "print(f\"Error máximo de seguimiento: {max_error:.4f} m\")\n",
+    "assert max_error < 0.02, \"El error de seguimiento excede el umbral de 2 cm\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Trayectorias"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig = plot_tracking(X, Xd, t)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Animación"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def arm_points(q: np.ndarray) -> np.ndarray:\n",
+    "    q1, q2 = q\n",
+    "    base = np.array([0.0, 0.0])\n",
+    "    joint = L1 * np.array([np.cos(q1), np.sin(q1)])\n",
+    "    end = joint + L2 * np.array([np.cos(q1 + q2), np.sin(q1 + q2)])\n",
+    "    return np.stack((base, joint, end), axis=1)\n",
+    "\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 5))\n",
+    "ax.set_aspect(\"equal\", adjustable=\"box\")\n",
+    "ax.set_xlim(-0.2, 0.6)\n",
+    "ax.set_ylim(-0.2, 0.6)\n",
+    "ax.set_xlabel(\"x [m]\")\n",
+    "ax.set_ylabel(\"y [m]\")\n",
+    "ax.set_title(\"Control cinemático RR\")\n",
+    "ax.plot(Xd[0], Xd[1], \"--\", color=\"tab:orange\", label=\"Trayectoria deseada\")\n",
+    "arm_line, = ax.plot([], [], \"o-\", lw=2, color=\"tab:blue\", label=\"Robot\")\n",
+    "ax.legend(loc=\"upper right\")\n",
+    "\n",
+    "frames = range(0, t.size, 2)\n",
+    "\n",
+    "\n",
+    "def init():\n",
+    "    arm_line.set_data([], [])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "def animate(i):\n",
+    "    pts = arm_points(q[:, i])\n",
+    "    arm_line.set_data(pts[0], pts[1])\n",
+    "    return (arm_line,)\n",
+    "\n",
+    "\n",
+    "anim = animation.FuncAnimation(\n",
+    "    fig, animate, init_func=init, frames=frames, interval=50, blit=True\n",
+    ")\n",
+    "HTML(anim.to_jshtml())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/control/control_rrr.ipynb
+++ b/notebooks/control/control_rrr.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import sympy as sp\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.animation import FuncAnimation\n",
+    "from IPython.display import HTML\n",
+    "from utils import time_vector, circular_task_reference, plot_tracking\n",
+    "\n",
+    "plt.style.use('seaborn-v0_8')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Control cinemático del manipulador RRR planar\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Parámetros\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params_rrr = {\n",
+    "    'L1': 0.7,\n",
+    "    'L2': 0.6,\n",
+    "    'L3': 0.4\n",
+    "}\n",
+    "\n",
+    "sim_config_rrr = {\n",
+    "    'kp': np.diag([9.0, 9.0, 6.0]),\n",
+    "    't0': 0.0,\n",
+    "    'tf': 10.0,\n",
+    "    'n_steps': 800\n",
+    "}\n",
+    "\n",
+    "t_rrr, dt_rrr = time_vector(sim_config_rrr)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Cinemática directa\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fkine_rrr(q, params):\n",
+    "    q1, q2, q3 = q\n",
+    "    L1, L2, L3 = params['L1'], params['L2'], params['L3']\n",
+    "    c1, s1 = np.cos(q1), np.sin(q1)\n",
+    "    c12, s12 = np.cos(q1 + q2), np.sin(q1 + q2)\n",
+    "    c123, s123 = np.cos(q1 + q2 + q3), np.sin(q1 + q2 + q3)\n",
+    "\n",
+    "    x = L1 * c1 + L2 * c12 + L3 * c123\n",
+    "    y = L1 * s1 + L2 * s12 + L3 * s123\n",
+    "    theta = q1 + q2 + q3\n",
+    "    return np.array([x, y, theta])\n",
+    "\n",
+    "fkine_rrr(np.zeros(3), params_rrr)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Jacobiano\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def jacobian_rrr(q, params):\n",
+    "    q1, q2, q3 = q\n",
+    "    L1, L2, L3 = params['L1'], params['L2'], params['L3']\n",
+    "\n",
+    "    s1 = np.sin(q1)\n",
+    "    c1 = np.cos(q1)\n",
+    "    s12 = np.sin(q1 + q2)\n",
+    "    c12 = np.cos(q1 + q2)\n",
+    "    s123 = np.sin(q1 + q2 + q3)\n",
+    "    c123 = np.cos(q1 + q2 + q3)\n",
+    "\n",
+    "    J = np.array([\n",
+    "        [-L1 * s1 - L2 * s12 - L3 * s123, -L2 * s12 - L3 * s123, -L3 * s123],\n",
+    "        [ L1 * c1 + L2 * c12 + L3 * c123,  L2 * c12 + L3 * c123,  L3 * c123],\n",
+    "        [1.0, 1.0, 1.0]\n",
+    "    ])\n",
+    "    return J\n",
+    "\n",
+    "jacobian_rrr(np.zeros(3), params_rrr)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Derivación simbólica\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q1_s, q2_s, q3_s, L1_s, L2_s, L3_s = sp.symbols('q1 q2 q3 L1 L2 L3')\n",
+    "px = L1_s * sp.cos(q1_s) + L2_s * sp.cos(q1_s + q2_s) + L3_s * sp.cos(q1_s + q2_s + q3_s)\n",
+    "py = L1_s * sp.sin(q1_s) + L2_s * sp.sin(q1_s + q2_s) + L3_s * sp.sin(q1_s + q2_s + q3_s)\n",
+    "pt = q1_s + q2_s + q3_s\n",
+    "J_symbolic = sp.Matrix([px, py, pt]).jacobian([q1_s, q2_s, q3_s])\n",
+    "sp.simplify(J_symbolic)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Trayectoria objetivo\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radius_rrr = 0.25\n",
+    "center_rrr = (1.1, 0.2)\n",
+    "omega_rrr = 0.7\n",
+    "\n",
+    "Xd_planar_rrr, Vd_planar_rrr = circular_task_reference(radius_rrr, center_rrr, omega_rrr, t_rrr)\n",
+    "theta_d_rrr = np.unwrap(np.arctan2(Vd_planar_rrr[1], Vd_planar_rrr[0]))\n",
+    "theta_dp_rrr = np.gradient(theta_d_rrr, t_rrr)\n",
+    "\n",
+    "Xd_rrr = np.vstack((Xd_planar_rrr, theta_d_rrr))\n",
+    "Vd_rrr = np.vstack((Vd_planar_rrr, theta_dp_rrr))\n",
+    "Xd_rrr[:, :3]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Control cinemático\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def kinematic_control_step_rrr(q, params, xd, xdp, kp):\n",
+    "    x = fkine_rrr(q, params)\n",
+    "    J = jacobian_rrr(q, params)\n",
+    "    dq = np.linalg.solve(J, xdp + kp @ (xd - x))\n",
+    "    return dq, x\n",
+    "\n",
+    "kinematic_control_step_rrr(np.zeros(3), params_rrr, Xd_rrr[:, 0], Vd_rrr[:, 0], sim_config_rrr['kp'])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Simulación\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simulate_rrr_control(q0, params, Xd, Vd, t, kp):\n",
+    "    n = t.size\n",
+    "    dt = t[1] - t[0]\n",
+    "    q = np.zeros((3, n))\n",
+    "    X = np.zeros((3, n))\n",
+    "    q[:, 0] = q0\n",
+    "    X[:, 0] = fkine_rrr(q0, params)\n",
+    "    for k in range(1, n):\n",
+    "        dq, _ = kinematic_control_step_rrr(q[:, k-1], params, Xd[:, k-1], Vd[:, k-1], kp)\n",
+    "        q[:, k] = q[:, k-1] + dt * dq\n",
+    "        X[:, k] = fkine_rrr(q[:, k])\n",
+    "    return q, X\n",
+    "\n",
+    "q0_rrr = np.array([0.1, -0.2, 0.3])\n",
+    "theta_rrr, X_rrr = simulate_rrr_control(q0_rrr, params_rrr, Xd_rrr, Vd_rrr, t_rrr, sim_config_rrr['kp'])\n",
+    "X_rrr[:, :3]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "theta_error_rrr = np.angle(np.exp(1j * (Xd_rrr[2] - X_rrr[2])))\n",
+    "position_error_rrr = np.linalg.norm(Xd_rrr[:2] - X_rrr[:2], axis=0)\n",
+    "max_pos_error_rrr = float(np.max(position_error_rrr))\n",
+    "max_theta_error_rrr = float(np.max(np.abs(theta_error_rrr)))\n",
+    "print(f'Error máximo de posición: {max_pos_error_rrr:.4f} m')\n",
+    "print(f'Error máximo de orientación: {max_theta_error_rrr:.4f} rad')\n",
+    "assert max_pos_error_rrr < 5e-2\n",
+    "assert max_theta_error_rrr < 8e-2\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Visualización\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig_rrr = plot_tracking(X_rrr[:2], Xd_rrr[:2], t_rrr)\n",
+    "fig_rrr.axes[0].set_title('Trayectoria planar (x, y)')\n",
+    "fig_rrr.axes[1].set_title('Errores de posición en el plano')\n",
+    "fig_rrr\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 3))\n",
+    "plt.plot(t_rrr, np.rad2deg(theta_error_rrr), label='Error de orientación')\n",
+    "plt.xlabel('Tiempo [s]')\n",
+    "plt.ylabel('Error [deg]')\n",
+    "plt.title('Seguimiento de la orientación θ')\n",
+    "plt.legend()\n",
+    "plt.grid(True)\n",
+    "plt.tight_layout()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Animación\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def animate_rrr(theta, X, Xd, params, skip=2):\n",
+    "    L1, L2, L3 = params['L1'], params['L2'], params['L3']\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(6, 6))\n",
+    "    ax.set_aspect('equal', adjustable='box')\n",
+    "    margin = 0.3\n",
+    "    x_all = np.concatenate([X[0], Xd[0]])\n",
+    "    y_all = np.concatenate([X[1], Xd[1]])\n",
+    "    ax.set_xlim(np.min(x_all) - margin, np.max(x_all) + margin)\n",
+    "    ax.set_ylim(np.min(y_all) - margin, np.max(y_all) + margin)\n",
+    "    ax.set_xlabel('x [m]')\n",
+    "    ax.set_ylabel('y [m]')\n",
+    "    ax.set_title('Robot planar RRR')\n",
+    "\n",
+    "    desired_line, = ax.plot(Xd[0], Xd[1], '--', linewidth=1.2, label='Trayectoria deseada')\n",
+    "    trail_line,   = ax.plot([], [], ':', linewidth=1.5, label='Rastro')\n",
+    "    link1_line, = ax.plot([], [], 'k-', linewidth=3)\n",
+    "    link2_line, = ax.plot([], [], 'k-', linewidth=3)\n",
+    "    link3_line, = ax.plot([], [], 'k-', linewidth=3)\n",
+    "    ee_point,   = ax.plot([], [], 'o', markersize=5)\n",
+    "    ax.legend(loc='upper right')\n",
+    "\n",
+    "    def joint_positions(q):\n",
+    "        q1, q2, q3 = q\n",
+    "        p0 = np.array([0.0, 0.0])\n",
+    "        p1 = p0 + np.array([L1 * np.cos(q1), L1 * np.sin(q1)])\n",
+    "        p2 = p1 + np.array([L2 * np.cos(q1 + q2), L2 * np.sin(q1 + q2)])\n",
+    "        p3 = p2 + np.array([L3 * np.cos(q1 + q2 + q3), L3 * np.sin(q1 + q2 + q3)])\n",
+    "        return p0, p1, p2, p3\n",
+    "\n",
+    "    trail_x, trail_y = [], []\n",
+    "\n",
+    "    def update(frame):\n",
+    "        k = frame * skip\n",
+    "        if k >= theta.shape[1]:\n",
+    "            k = theta.shape[1] - 1\n",
+    "        q = theta[:, k]\n",
+    "        p0, p1, p2, p3 = joint_positions(q)\n",
+    "        link1_line.set_data([p0[0], p1[0]], [p0[1], p1[1]])\n",
+    "        link2_line.set_data([p1[0], p2[0]], [p1[1], p2[1]])\n",
+    "        link3_line.set_data([p2[0], p3[0]], [p2[1], p3[1]])\n",
+    "        ee_point.set_data(p3[0], p3[1])\n",
+    "        trail_x.append(p3[0])\n",
+    "        trail_y.append(p3[1])\n",
+    "        trail_line.set_data(trail_x, trail_y)\n",
+    "        return link1_line, link2_line, link3_line, ee_point, trail_line\n",
+    "\n",
+    "    frames = max(1, theta.shape[1] // skip)\n",
+    "    anim = FuncAnimation(fig, update, frames=frames, interval=40, blit=True, repeat=False)\n",
+    "    plt.close(fig)\n",
+    "    return anim\n",
+    "\n",
+    "anim_rrr = animate_rrr(theta_rrr, X_rrr, Xd_rrr, params_rrr)\n",
+    "HTML(anim_rrr.to_jshtml())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/control/utils.py
+++ b/notebooks/control/utils.py
@@ -1,0 +1,60 @@
+"""Funciones auxiliares compartidas entre los cuadernos de control cinemático."""
+
+from __future__ import annotations
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def time_vector(cfg: dict) -> tuple[np.ndarray, float]:
+    """Genera un vector de tiempo uniforme a partir de la configuración."""
+    t = np.linspace(cfg['t0'], cfg['tf'], cfg['n_steps'])
+    if t.size < 2:
+        raise ValueError('Se requieren al menos dos pasos de simulación')
+    dt = float(t[1] - t[0])
+    return t, dt
+
+
+def circular_task_reference(
+    radius: float,
+    center: tuple[float, float],
+    omega: float,
+    t: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Genera referencias cartesianas en trayectoria circular."""
+    if t is None:
+        raise ValueError('Se requiere un vector de tiempo "t"')
+    cx, cy = center
+    xd = cx + radius * np.cos(omega * t)
+    yd = cy + radius * np.sin(omega * t)
+    xdp = -radius * omega * np.sin(omega * t)
+    ydp = radius * omega * np.cos(omega * t)
+    Xd = np.vstack((xd, yd))
+    Vd = np.vstack((xdp, ydp))
+    return Xd, Vd
+
+
+def plot_tracking(X: np.ndarray, Xd: np.ndarray, t: np.ndarray) -> plt.Figure:
+    """Grafica la trayectoria seguida y los errores de seguimiento."""
+    fig, ax = plt.subplots(1, 2, figsize=(12, 4))
+
+    ax[0].plot(Xd[0], Xd[1], '--', label='Deseada')
+    ax[0].plot(X[0], X[1], label='Seguimiento')
+    ax[0].set_aspect('equal', adjustable='box')
+    ax[0].set_xlabel('x [m]')
+    ax[0].set_ylabel('y [m]')
+    ax[0].legend()
+    ax[0].set_title('Trayectorias cartesianas')
+
+    ax[1].plot(t, Xd[0] - X[0], label='Error en x')
+    ax[1].plot(t, Xd[1] - X[1], label='Error en y')
+    ax[1].set_xlabel('Tiempo [s]')
+    ax[1].set_ylabel('Error [m]')
+    ax[1].legend()
+    ax[1].set_title('Errores de seguimiento')
+
+    fig.tight_layout()
+    return fig
+
+
+__all__ = ['time_vector', 'circular_task_reference', 'plot_tracking']


### PR DESCRIPTION
## Summary
- recreate the planar PR, RP, and RR kinematic-control notebooks with consistent setup, kinematics, error validation, and circular-trajectory animations
- revise the spatial 4-DOF control notebook to model all four links, add pose tracking checks, and thin the animation frames to stay within the embed limit

## Testing
- not run (numpy missing in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68deb87432448333b8ff338240d7bc29